### PR TITLE
Add technical indicators with scaled signals

### DIFF
--- a/combine_signals.py
+++ b/combine_signals.py
@@ -11,6 +11,20 @@ from mp_support_resist import (
 )
 from harmonic_patterns import get_extremes, find_xabcd, ALL_PATTERNS
 
+# ``StandardScaler`` is used to normalise the various signal columns so that the
+# resulting dataframe can be directly fed into machine learning models. The
+# import is optional to keep the core functionality lightweight when scaling is
+# not required.
+try:
+    from sklearn.preprocessing import StandardScaler
+except Exception:  # pragma: no cover - only executed if sklearn missing
+    StandardScaler = None
+
+# Optional dependency used for additional technical indicators. The library
+# provides dozens of common indicators which we expose as extra columns in the
+# combined dataframe. The import is performed lazily inside ``ta_indicators`` to
+# avoid the dependency when not required.
+
 
 def load_data(path="BTCUSDT3600.csv"):
     data = pd.read_csv(path)
@@ -55,9 +69,38 @@ def sr_signals(data, lookback=365):
     return sr_penetration_signal(data, levels)
 
 
+def ta_indicators(data: pd.DataFrame) -> pd.DataFrame:
+    """Return a dataframe of technical indicator columns.
+
+    This function relies on the ``ta`` package which includes a wide range of
+    indicators. If the package is not installed, an informative error will be
+    raised.
+    """
+
+    try:
+        from ta import add_all_ta_features
+    except Exception as exc:  # pragma: no cover - only executed if ta missing
+        raise ImportError("The 'ta' package is required for additional indicators" ) from exc
+
+    df = data.copy()
+    if "volume" not in df.columns:
+        df["volume"] = 1.0
+    df = add_all_ta_features(
+        df,
+        open="open",
+        high="high",
+        low="low",
+        close="close",
+        volume="volume",
+        fillna=True,
+    )
+    extra_cols = [c for c in df.columns if c not in data.columns]
+    return df[extra_cols]
+
+
 
 def aggregate_signals(path: str = "BTCUSDT3600.csv", include_pip_miner: bool = False) -> pd.DataFrame:
-    """Return a dataframe with a signal column for each strategy.
+    """Return a dataframe with OHLC values and scaled trading signals.
 
     Parameters
     ----------
@@ -75,12 +118,15 @@ def aggregate_signals(path: str = "BTCUSDT3600.csv", include_pip_miner: bool = F
     hs_sig = head_shoulders_signals(log_close)
     flag_sig = flag_pennant_signals(log_close)
     harm_sig = harmonic_signals(data)
+    ta_df = ta_indicators(data)
 
-    df = pd.DataFrame(index=data.index)
-    df["sr_signal"] = sr_sig
-    df["hs_signal"] = hs_sig
-    df["flag_signal"] = flag_sig
-    df["harmonic_signal"] = harm_sig
+    signal_df = pd.DataFrame(index=data.index)
+    signal_df["sr_signal"] = sr_sig
+    signal_df["hs_signal"] = hs_sig
+    signal_df["flag_signal"] = flag_sig
+    signal_df["harmonic_signal"] = harm_sig
+    for col in ta_df.columns:
+        signal_df[col] = ta_df[col]
 
     if include_pip_miner:
         from wf_pip_miner import WFPIPMiner
@@ -95,9 +141,21 @@ def aggregate_signals(path: str = "BTCUSDT3600.csv", include_pip_miner: bool = F
         pip_sig = np.zeros(len(log_close))
         for i in range(len(log_close)):
             pip_sig[i] = miner.update_signal(log_close, i)
-        df["pip_miner_signal"] = pip_sig
+        signal_df["pip_miner_signal"] = pip_sig
 
-    df["combined_signal"] = df.sum(axis=1)
+    # Scale all signal columns so the features have comparable magnitudes
+    if StandardScaler is not None:
+        scaler = StandardScaler()
+        signal_df[signal_df.columns] = scaler.fit_transform(signal_df)
+
+    signal_df["combined_signal"] = signal_df.sum(axis=1)
+
+    # Add OHLC columns to the returned dataframe
+    df = pd.DataFrame(index=data.index)
+    for col in ["open", "high", "low", "close"]:
+        if col in data.columns:
+            df[col] = data[col]
+    df = pd.concat([df, signal_df], axis=1)
     return df
 
 

--- a/mp_support_resist.py
+++ b/mp_support_resist.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import mplfinance as mpf
 import scipy
 import math
-import pandas_ta as ta
+from ta.volatility import AverageTrueRange
 
 
 def find_levels( 
@@ -49,8 +49,15 @@ def support_resistance_levels(
         first_w: float = 0.01, atr_mult:float=3.0, prom_thresh:float =0.25
 ):
 
-    # Get log average true range, 
-    atr = ta.atr(np.log(data['high']), np.log(data['low']), np.log(data['close']), lookback)
+    # Get log average true range using the ``ta`` package
+    atr_ind = AverageTrueRange(
+        np.log(data['high']),
+        np.log(data['low']),
+        np.log(data['close']),
+        window=lookback,
+        fillna=True,
+    )
+    atr = atr_ind.average_true_range()
 
     all_levels = [None] * len(data)
     for i in range(lookback, len(data)):


### PR DESCRIPTION
## Summary
- add StandardScaler to normalize signal features
- scale each signal and include OHLC columns in `aggregate_signals`
- remove incompatible `pandas_ta` dependency by using `AverageTrueRange`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt due to long-running existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684ec385c84c83258a256d4e4d466317